### PR TITLE
chore: track .serena/memories, ignore tool config and cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ poetry.lock
 
 # OS
 .DS_Store
+# Serena (track memories, ignore config/cache)
+.serena/cache/
+.serena/project*.yml

--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml


### PR DESCRIPTION
Track AI agent memories (.serena/memories/) for cross-developer knowledge sharing, while ignoring machine-specific tool config (.serena/project*.yml) and caches (.serena/cache/).