### PR TITLE
feat: add A sistemo espanso manager (#17)

### DIFF
--- a/src/A_sistemo/cli/espanso_alias.py
+++ b/src/A_sistemo/cli/espanso_alias.py
@@ -1,0 +1,148 @@
+"""CLI for sistemo espanso command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+from rich.box import SIMPLE as BOX_SIMPLE
+
+from A import info, error, tr
+from A_sistemo.services import EspansoMatch, EspansoMatchDB
+
+app = typer.Typer(
+    name="espanso",
+    help=tr("espanso_matches"),
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+console = Console()
+
+
+def _get_db() -> EspansoMatchDB:
+    """Get the espanso match database."""
+    return EspansoMatchDB(Path.home() / ".config" / "A" / "espanso_matches.db")
+
+
+def _show_matches(matches: list[EspansoMatch]) -> None:
+    """Display matches in a rich table."""
+    if not matches:
+        info(tr("neniu_matches"))
+        return
+    table = Table(box=BOX_SIMPLE, title=tr("espanso_matches"))
+    table.add_column("UID", style="cyan")
+    table.add_column(tr("trigger"), style="green")
+    table.add_column(tr("replace"))
+    for m in matches:
+        table.add_row(str(m.uid), m.trigger, m.replace_text[:60])
+    console.print(table)
+
+
+@app.command("ls")
+def ls(
+    alfabeto: bool = typer.Option(False, "-A", "--alfabeto", help=tr("alfabetaordo")),
+    inversigi: bool = typer.Option(False, "-i", "--inversigi", help=tr("inversaordo")),
+) -> None:
+    """List espanso matches."""
+    db = _get_db()
+    sort_by = "trigger" if alfabeto else "created_at"
+    matches = db.list_matches(sort_by=sort_by, descending=not inversigi)
+    _show_matches(matches)
+
+
+@app.command("aldoni")
+def aldoni(
+    trigger: str = typer.Option(..., "-t", "--trigger", help=tr("trigger_example")),
+    replace_text: str = typer.Option(..., "-r", "--replace", help=tr("replace_text")),
+    notes: str = typer.Option("", "-n", "--notes", help=tr("notes")),
+) -> None:
+    """Add new espanso match."""
+    db = _get_db()
+    uid = db.add_match(trigger, replace_text, notes or None)
+    db.sync_espanso_config()
+    info(f"{tr('added')}: UID {uid}")
+
+
+@app.command("modifi")
+def modifi(
+    uid: int = typer.Argument(..., help="UID (Example: 1)"),
+    trigger: Optional[str] = typer.Option(None, "-t", "--trigger", help=tr("trigger")),
+    replace_text: Optional[str] = typer.Option(None, "-r", "--replace", help=tr("replace_text")),
+    notes: Optional[str] = typer.Option(None, "-n", "--notes", help=tr("notes")),
+) -> None:
+    """Modify espanso match."""
+    db = _get_db()
+    if db.update_match(uid, trigger, replace_text, notes):
+        db.sync_espanso_config()
+        info(f"{tr('modified')}: UID {uid}")
+    else:
+        error(f"{tr('ne_trovita_uid')} {uid}")
+        raise typer.Exit(1)
+
+
+@app.command("forigi")
+def forigi(
+    uids: list[int] = typer.Argument(..., help="UIDs (Example: 1 2)"),
+    justa: bool = typer.Option(False, "-j", "--justa", help=tr("sen_konfirmo")),
+) -> None:
+    """Delete espanso matches."""
+    if not uids:
+        error(tr("minimun_unu_uid"))
+        raise typer.Exit(1)
+    db = _get_db()
+    for uid in uids:
+        db.delete_match(uid)
+    db.sync_espanso_config()
+    info(f"{tr('deleted')}: {len(uids)} matchoj")
+
+
+@app.command("vidi")
+def vidi(uid: int = typer.Argument(..., help="UID (Example: 1)")) -> None:
+    """View espanso match details."""
+    db = _get_db()
+    m = db.get_match(uid)
+    if not m:
+        error(f"{tr('ne_trovita_uid')} {uid}")
+        raise typer.Exit(1)
+    info(f"{tr('trigger')}: {m.trigger}")
+    info(f"{tr('replace')}: {m.replace_text}")
+    if m.notes:
+        info(f"{tr('notes')}: {m.notes}")
+
+
+@app.command("serci")
+def serci(query: str = typer.Argument("", help=tr("sercho_termino"))) -> None:
+    """Search espanso matches."""
+    db = _get_db()
+    results = db.search_matches(query)
+    _show_matches(results)
+
+
+@app.command("migri")
+def migri() -> None:
+    """Import existing espanso matches from config files."""
+    from A import success
+    from A_sistemo.services.espanso_alias_db import migrate_from_existing
+
+    db = _get_db()
+    result = migrate_from_existing(db)
+
+    if result["files_found"] == 0:
+        info("No espanso config files found.")
+        return
+
+    info(f"Files found: {result['files_found']}, matches: {result['matches_found']}")
+    success(f"Migrated: {result['migrated']}, skipped (duplicates): {result['skipped']}")
+
+    for err in result.get("errors", []):
+        from A import warning
+        warning(f"  {err}")
+
+    if result["migrated"] > 0:
+        db.sync_espanso_config()
+        info("Espanso config synced.")
+
+
+__all__ = ["app"]

--- a/src/A_sistemo/cli/sistemo.py
+++ b/src/A_sistemo/cli/sistemo.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import typer
 
 from A import tr
-from A_sistemo.cli import info, wifi, bluetooth, usb, disko, rubo, bash_alias, particio
+from A_sistemo.cli import info, wifi, bluetooth, usb, disko, rubo, bash_alias, particio, espanso_alias
 
 app = typer.Typer(
     name="sistemo",
@@ -23,6 +23,7 @@ app.add_typer(rubo.app, name="rubo")
 
 # Add sistemo-specific subcommands
 app.add_typer(bash_alias.app, name="selo-aliaso")
+app.add_typer(espanso_alias.app, name="espanso")
 app.add_typer(particio.app, name="particio")
 app.command(name="info")(info.show_info)
 

--- a/src/A_sistemo/services/__init__.py
+++ b/src/A_sistemo/services/__init__.py
@@ -9,6 +9,7 @@ from A_sistemo.services.usb_service import list_devices as usb_list_devices
 from A_sistemo.services.disk_service import DiskDevice, SMARTInfo, list_devices, get_smart_info, mount, unmount
 from A_sistemo.services.recycle_bin import TrashItem, list_items, move_to_trash, restore, delete_permanent
 from A_sistemo.services.bash_alias_db import BashAlias, BashAliasDB
+from A_sistemo.services.espanso_alias_db import EspansoMatch, EspansoMatchDB
 from A_sistemo.services.partition_service import shrink, create, format
 from A_sistemo.services.installer import get_poetry_env_path, install_binary, generate_shell_aliases, setup_bashrc
 
@@ -46,6 +47,8 @@ __all__ = [
     "delete_permanent",
     "BashAlias",
     "BashAliasDB",
+    "EspansoMatch",
+    "EspansoMatchDB",
     "shrink",
     "create",
     "format",

--- a/src/A_sistemo/services/espanso_alias_db.py
+++ b/src/A_sistemo/services/espanso_alias_db.py
@@ -1,0 +1,278 @@
+"""Espanso match database service.
+
+Manages espanso text expansion matches in a SQLite database.
+Generates a read-only YAML file consumed by espanso.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from A.data.base import SQLiteDB
+
+
+# Espanso match directory
+_ESPANSO_MATCH_DIR = Path.home() / ".config" / "espanso" / "match"
+_A_ESPANSO_FILE = _ESPANSO_MATCH_DIR / "A_espanso.yml"
+
+
+@dataclass
+class EspansoMatch:
+    """Represents a single espanso text expansion match."""
+
+    uid: int
+    trigger: str
+    replace_text: str
+    notes: Optional[str]
+    created_at: Optional[datetime]
+    updated_at: Optional[datetime]
+
+
+# Schema for the matches table
+SCHEMA = {
+    "matches": """
+        CREATE TABLE IF NOT EXISTS matches (
+            uid INTEGER PRIMARY KEY,
+            trigger TEXT UNIQUE NOT NULL,
+            replace_text TEXT NOT NULL,
+            notes TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT
+        )
+    """,
+    "idx_trigger": "CREATE INDEX IF NOT EXISTS idx_trigger ON matches(trigger)",
+    "idx_created_at": "CREATE INDEX IF NOT EXISTS idx_created_at2 ON matches(created_at)",
+}
+
+
+class EspansoMatchDB:
+    """Espanso match database using A.data.base.SQLiteDB."""
+
+    def __init__(self, db_path: Path):
+        self.db_path = db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._db = SQLiteDB(db_path, SCHEMA)
+
+    def _row_to_match(self, row: dict) -> EspansoMatch:
+        """Convert database row to EspansoMatch dataclass."""
+        return EspansoMatch(
+            uid=row["uid"],
+            trigger=row["trigger"],
+            replace_text=row["replace_text"],
+            notes=row["notes"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+    def add_match(self, trigger: str, replace_text: str, notes: Optional[str] = None) -> int:
+        """Add a new espanso match."""
+        now = datetime.now(timezone.utc).isoformat()
+        with self._db.transaction() as conn:
+            cursor = conn.execute(
+                "INSERT INTO matches (trigger, replace_text, notes, created_at) VALUES (?, ?, ?, ?)",
+                (trigger, replace_text, notes, now),
+            )
+            return cursor.lastrowid
+
+    def get_match(self, uid: int) -> Optional[EspansoMatch]:
+        """Get match by uid."""
+        row = self._db.execute_one(
+            "SELECT uid, trigger, replace_text, notes, created_at, updated_at FROM matches WHERE uid = ?",
+            (uid,),
+        )
+        return self._row_to_match(row) if row else None
+
+    def list_matches(self, sort_by: str = "created_at", descending: bool = True) -> list[EspansoMatch]:
+        """List all matches."""
+        valid_sort = {"trigger", "created_at", "updated_at"}
+        if sort_by not in valid_sort:
+            sort_by = "created_at"
+        order = "DESC" if descending else "ASC"
+        rows = self._db.execute(
+            f"SELECT uid, trigger, replace_text, notes, created_at, updated_at FROM matches ORDER BY {sort_by} {order}"
+        )
+        return [self._row_to_match(r) for r in rows]
+
+    def update_match(
+        self,
+        uid: int,
+        trigger: Optional[str] = None,
+        replace_text: Optional[str] = None,
+        notes: Optional[str] = None,
+    ) -> bool:
+        """Update an existing match."""
+        updates = []
+        values = []
+        if trigger is not None:
+            updates.append("trigger = ?")
+            values.append(trigger)
+        if replace_text is not None:
+            updates.append("replace_text = ?")
+            values.append(replace_text)
+        if notes is not None:
+            updates.append("notes = ?")
+            values.append(notes)
+        if updates:
+            updates.append("updated_at = ?")
+            values.append(datetime.now(timezone.utc).isoformat())
+            values.append(uid)
+            with self._db.transaction() as conn:
+                conn.execute(f"UPDATE matches SET {', '.join(updates)} WHERE uid = ?", tuple(values))
+            return True
+        return False
+
+    def delete_match(self, uid: int) -> bool:
+        """Delete a match by uid."""
+        with self._db.transaction() as conn:
+            conn.execute("DELETE FROM matches WHERE uid = ?", (uid,))
+        return True
+
+    def search_matches(self, query: str) -> list[EspansoMatch]:
+        """Search matches by trigger, replace_text, or notes."""
+        rows = self._db.execute(
+            "SELECT uid, trigger, replace_text, notes, created_at, updated_at FROM matches "
+            "WHERE trigger LIKE ? OR replace_text LIKE ? OR notes LIKE ?",
+            (f"%{query}%", f"%{query}%", f"%{query}%"),
+        )
+        return [self._row_to_match(r) for r in rows]
+
+    def sync_espanso_config(self) -> None:
+        """Sync matches to espanso match file (generated, read-only)."""
+        matches = self.list_matches()
+        lines = ["matches:"]
+        for m in matches:
+            trigger_val = m.trigger
+            replace_val = m.replace_text
+            # Use single quotes for clean YAML quoting
+            lines.append(f'- trigger: \'{trigger_val}\'')
+            lines.append(f"  replace: '{replace_val}'")
+
+        # Ensure espanso match directory exists
+        _ESPANSO_MATCH_DIR.mkdir(parents=True, exist_ok=True)
+
+        config = _A_ESPANSO_FILE
+        if config.exists():
+            config.chmod(0o644)  # Make writable before overwriting
+        config.write_text("\n".join(lines) + "\n")
+        config.chmod(0o444)  # Read-only to prevent user edits
+
+    def close(self) -> None:
+        """Close database connection (no-op for SQLiteDB)."""
+        pass
+
+
+def migrate_from_existing(target_db: EspansoMatchDB) -> dict:
+    """Import existing espanso match files into the A database.
+
+    Reads all .yml files from ~/.config/espanso/match/ (except A_espanso.yml)
+    and imports any matches found.
+
+    Args:
+        target_db: Target EspansoMatchDB to migrate into
+
+    Returns:
+        Dict with migration results
+    """
+    results = {
+        "files_found": 0,
+        "matches_found": 0,
+        "migrated": 0,
+        "skipped": 0,
+        "errors": [],
+    }
+
+    if not _ESPANSO_MATCH_DIR.exists():
+        return results
+
+    # Get existing triggers for idempotency
+    existing = {m.trigger for m in target_db.list_matches()}
+
+    for yml_path in sorted(_ESPANSO_MATCH_DIR.glob("*.yml")):
+        # Skip our own generated file
+        if yml_path.name == "A_espanso.yml":
+            continue
+
+        results["files_found"] += 1
+
+        # Simple YAML parser for espanso match format.
+        # We parse line-by-line instead of using yaml lib to avoid a dependency.
+        matches = _parse_espanso_yml(yml_path)
+        results["matches_found"] += len(matches)
+
+        for trigger, replace_text in matches:
+            if trigger in existing:
+                results["skipped"] += 1
+                continue
+
+            try:
+                target_db.add_match(trigger=trigger, replace_text=replace_text)
+                results["migrated"] += 1
+                existing.add(trigger)
+            except Exception as e:
+                results["errors"].append(f"{trigger} ({yml_path.name}): {e}")
+
+    return results
+
+
+def _parse_espanso_yml(path: Path) -> list[tuple[str, str]]:
+    """Simple line-based parser for espanso match YAML files.
+
+    Only handles basic format:
+        matches:
+        - trigger: ':xyz'
+          replace: 'text'
+
+    Args:
+        path: Path to YAML file
+
+    Returns:
+        List of (trigger, replace_text) tuples
+    """
+    content = path.read_text()
+    matches: list[tuple[str, str]] = []
+    current_trigger = None
+    current_replace = None
+
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        # Detect trigger field
+        trigger_match = re.match(r"^-?\s*trigger:\s*'([^']*)'", stripped)
+        if trigger_match:
+            # Save previous pair if exists
+            if current_trigger is not None and current_replace is not None:
+                matches.append((current_trigger, current_replace))
+            current_trigger = trigger_match.group(1)
+            current_replace = None
+            continue
+
+        # Detect replace field
+        replace_match = re.match(r"^\s*replace:\s*'([^']*)'", stripped)
+        if replace_match and current_trigger is not None:
+            current_replace = replace_match.group(1)
+
+        # Handle unquoted values
+        if current_replace is None:
+            replace_match = re.match(r"^\s*replace:\s*\"([^\"]*)\"", stripped)
+            if replace_match and current_trigger is not None:
+                current_replace = replace_match.group(1)
+
+        if current_replace is None:
+            replace_match = re.match(r"^\s*replace:\s*(\S.*)", stripped)
+            if replace_match and current_trigger is not None:
+                current_replace = replace_match.group(1)
+
+    # Save last pair
+    if current_trigger is not None and current_replace is not None:
+        matches.append((current_trigger, current_replace))
+
+    return matches
+
+
+__all__ = ["EspansoMatch", "EspansoMatchDB", "migrate_from_existing"]


### PR DESCRIPTION
## Summary
Add `A sistemo espanso` command group to manage espanso text expansion matches.

## Changes
- **New service**: `EspansoMatchDB` — CRUD + sync to espanso YAML file
- **New CLI**: espanso sub-typer with `ls`, `aldoni`, `modifi`, `forigi`, `vidi`, `serci`, `migri`
- **migri**: imports existing espanso matches from `~/.config/espanso/match/*.yml`
- Generated YAML at `~/.config/espanso/match/A_espanso.yml` (RO)

## Usage
```bash
A sistemo espanso ls                     # List matches
A sistemo espanso aldoni  -t ":ab" -r "hello world"  # Add match
A sistemo espanso forigi  <uid>          # Delete match
A sistemo espanso migri                  # Import existing matches
```