### PR TITLE
feat: add selo-funkcio for multiline bash functions (#20)

### DIFF
--- a/src/A_sistemo/cli/bash_function.py
+++ b/src/A_sistemo/cli/bash_function.py
@@ -1,0 +1,186 @@
+"""CLI for sistemo selo-funkcio command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+from rich.box import SIMPLE as BOX_SIMPLE
+
+from A import info, error, tr
+from A_sistemo.services import BashFunction, BashFunctionDB
+from A_sistemo.services.bash_function_db import parse_function_file, validate_bash_syntax
+
+app = typer.Typer(
+    name="selo-funkcio",
+    help=tr("bash_functions"),
+    no_args_is_help=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+console = Console()
+
+
+def _get_db() -> BashFunctionDB:
+    """Get the bash function database."""
+    return BashFunctionDB(Path.home() / ".config" / "A" / "bash_functions.db")
+
+
+def _show_functions(functions: list[BashFunction]) -> None:
+    """Display functions in a rich table."""
+    if not functions:
+        info(tr("neniu_funkcio"))
+        return
+    table = Table(box=BOX_SIMPLE, title=tr("bash_functions"))
+    table.add_column("UID", style="bold")
+    table.add_column(tr("name"))
+    for f in functions:
+        # Show first line of body as preview
+        preview = f.body.splitlines()[0] if f.body else ""
+        table.add_row(str(f.uid), f.name, preview[:60])
+    console.print(table)
+
+
+@app.command("ls")
+def ls(
+    alfabeto: bool = typer.Option(False, "-A", "--alfabeto", help=tr("alfabetaordo")),
+) -> None:
+    """List bash functions."""
+    db = _get_db()
+    sort_by = "name" if alfabeto else "created_at"
+    functions = db.list_functions(sort_by=sort_by, descending=False if alfabeto else True)
+    _show_functions(functions)
+
+
+@app.command("aldoni")
+def aldoni(
+    file_path: Path = typer.Argument(
+        ...,
+        help=tr("path_to_function_file"),
+        exists=True,
+        readable=True,
+    ),
+) -> None:
+    """Add bash function from file."""
+    try:
+        name, body = parse_function_file(file_path)
+        validate_bash_syntax(name, body)
+    except (ValueError, OSError) as e:
+        error(f"{e}")
+        raise typer.Exit(1)
+
+    db = _get_db()
+    existing = db.get_function_by_name(name)
+    if existing:
+        error(f"Function '{name}' already exists (UID {existing.uid}).")
+        info("Use 'selo-funkcio modifi' to update it.")
+        raise typer.Exit(1)
+
+    uid = db.add_function(name=name, body=body)
+    db.sync_shell_config()
+    info(f"{tr('added')}: {name} (UID {uid})")
+
+
+@app.command("modifi")
+def modifi(
+    uid: int = typer.Argument(..., help="UID (Example: 1)"),
+    file_path: Optional[Path] = typer.Option(
+        None,
+        "-f", "--file",
+        help=tr("path_to_function_file"),
+        exists=True,
+        readable=True,
+    ),
+    name: Optional[str] = typer.Option(None, "-n", "--name", help=tr("new_name")),
+) -> None:
+    """Modify a bash function."""
+    db = _get_db()
+    func = db.get_function(uid)
+    if not func:
+        error(f"{tr('ne_trovita_uid')} {uid}")
+        raise typer.Exit(1)
+
+    new_name = name
+    new_body = None
+
+    if file_path:
+        try:
+            parsed_name, new_body = parse_function_file(file_path)
+            if new_name is None:
+                new_name = parsed_name
+        except (ValueError, OSError) as e:
+            error(f"{e}")
+            raise typer.Exit(1)
+
+    if new_name or new_body:
+        try:
+            validate_bash_syntax(
+                new_name or func.name,
+                new_body or func.body,
+            )
+        except ValueError as e:
+            error(f"{e}")
+            raise typer.Exit(1)
+
+    if db.update_function(uid, name=new_name, body=new_body):
+        db.sync_shell_config()
+        info(f"{tr('modified')}: UID {uid}")
+    else:
+        error(f"{tr('ne_trovita_uid')} {uid}")
+        raise typer.Exit(1)
+
+
+@app.command("forigi")
+def forigi(
+    uids: list[int] = typer.Argument(..., help="UIDs (Example: 1 2)"),
+) -> None:
+    """Delete bash functions."""
+    if not uids:
+        error(tr("minimun_unu_uid"))
+        raise typer.Exit(1)
+    db = _get_db()
+    deleted = 0
+    not_found: list[int] = []
+    for uid in uids:
+        if db.delete_function(uid):
+            deleted += 1
+        else:
+            not_found.append(uid)
+    if not_found:
+        for uid in not_found:
+            error(f"UID {uid}: {tr('ne_trovita_uid')}")
+    if deleted > 0:
+        db.sync_shell_config()
+        info(f"{tr('forigita')}: {deleted} funkcioj")
+    else:
+        raise typer.Exit(1)
+
+
+@app.command("vidi")
+def vidi(uid: int = typer.Argument(..., help="UID (Example: 1)")) -> None:
+    """View bash function details."""
+    db = _get_db()
+    f = db.get_function(uid)
+    if not f:
+        error(f"{tr('ne_trovita_uid')} {uid}")
+        raise typer.Exit(1)
+
+    info(f"Name: {f.name}")
+    console.print(f"Body:")
+    console.print(f"{f.name}() {{")
+    for line in f.body.splitlines():
+        console.print(f"  {line}")
+    console.print("}")
+
+
+@app.command("serci")
+def serci(query: str = typer.Argument("", help=tr("sercho_termino"))) -> None:
+    """Search bash functions."""
+    db = _get_db()
+    results = db.search_functions(query)
+    _show_functions(results)
+
+
+__all__ = ["app"]

--- a/src/A_sistemo/cli/sistemo.py
+++ b/src/A_sistemo/cli/sistemo.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import typer
 
 from A import tr
-from A_sistemo.cli import info, wifi, bluetooth, usb, disko, rubo, bash_alias, particio, espanso_alias
+from A_sistemo.cli import info, wifi, bluetooth, usb, disko, rubo, bash_alias, bash_function, particio, espanso_alias
 
 app = typer.Typer(
     name="sistemo",
@@ -23,6 +23,7 @@ app.add_typer(rubo.app, name="rubo")
 
 # Add sistemo-specific subcommands
 app.add_typer(bash_alias.app, name="selo-aliaso")
+app.add_typer(bash_function.app, name="selo-funkcio")
 app.add_typer(espanso_alias.app, name="espanso")
 app.add_typer(particio.app, name="particio")
 app.command(name="info")(info.show_info)

--- a/src/A_sistemo/services/__init__.py
+++ b/src/A_sistemo/services/__init__.py
@@ -9,6 +9,7 @@ from A_sistemo.services.usb_service import list_devices as usb_list_devices
 from A_sistemo.services.disk_service import DiskDevice, SMARTInfo, list_devices, get_smart_info, mount, unmount
 from A_sistemo.services.recycle_bin import TrashItem, list_items, move_to_trash, restore, delete_permanent
 from A_sistemo.services.bash_alias_db import BashAlias, BashAliasDB
+from A_sistemo.services.bash_function_db import BashFunction, BashFunctionDB
 from A_sistemo.services.espanso_alias_db import EspansoMatch, EspansoMatchDB
 from A_sistemo.services.partition_service import shrink, create, format
 from A_sistemo.services.installer import get_poetry_env_path, install_binary, generate_shell_aliases, setup_bashrc
@@ -47,6 +48,8 @@ __all__ = [
     "delete_permanent",
     "BashAlias",
     "BashAliasDB",
+    "BashFunction",
+    "BashFunctionDB",
     "EspansoMatch",
     "EspansoMatchDB",
     "shrink",

--- a/src/A_sistemo/services/bash_function_db.py
+++ b/src/A_sistemo/services/bash_function_db.py
@@ -1,0 +1,248 @@
+"""Bash function database service.
+
+Manages multiline bash functions in a SQLite database.
+Generates a read-only shell script consumed by bash.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from A.data.base import SQLiteDB
+
+
+# Generated file path
+_A_BASH_FUNCTIONS = Path.home() / ".A_bash_functions"
+
+
+@dataclass
+class BashFunction:
+    """Represents a stored bash function."""
+
+    uid: int
+    name: str
+    body: str
+    created_at: Optional[datetime]
+    updated_at: Optional[datetime]
+
+
+# Schema for the functions table
+SCHEMA = {
+    "functions": """
+        CREATE TABLE IF NOT EXISTS functions (
+            uid INTEGER PRIMARY KEY,
+            name TEXT UNIQUE NOT NULL,
+            body TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT
+        )
+    """,
+    "idx_name": "CREATE INDEX IF NOT EXISTS idx_name ON functions(name)",
+    "idx_created_at": "CREATE INDEX IF NOT EXISTS idx_ct3 ON functions(created_at)",
+}
+
+
+class BashFunctionDB:
+    """Bash function database using A.data.base.SQLiteDB."""
+
+    def __init__(self, db_path: Path):
+        self.db_path = db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._db = SQLiteDB(db_path, SCHEMA)
+
+    def _row_to_function(self, row: dict) -> BashFunction:
+        """Convert database row to BashFunction dataclass."""
+        return BashFunction(
+            uid=row["uid"],
+            name=row["name"],
+            body=row["body"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+    def add_function(self, name: str, body: str) -> int:
+        """Add a new bash function.
+
+        Args:
+            name: Function name
+            body: Function body (inside the braces, without the name() { } wrapper)
+
+        Returns:
+            UID of the new function
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        with self._db.transaction() as conn:
+            cursor = conn.execute(
+                "INSERT INTO functions (name, body, created_at) VALUES (?, ?, ?)",
+                (name, body, now),
+            )
+            return cursor.lastrowid
+
+    def get_function(self, uid: int) -> Optional[BashFunction]:
+        """Get function by uid."""
+        row = self._db.execute_one(
+            "SELECT uid, name, body, created_at, updated_at FROM functions WHERE uid = ?",
+            (uid,),
+        )
+        return self._row_to_function(row) if row else None
+
+    def get_function_by_name(self, name: str) -> Optional[BashFunction]:
+        """Get function by name."""
+        row = self._db.execute_one(
+            "SELECT uid, name, body, created_at, updated_at FROM functions WHERE name = ?",
+            (name,),
+        )
+        return self._row_to_function(row) if row else None
+
+    def list_functions(self, sort_by: str = "created_at", descending: bool = True) -> list[BashFunction]:
+        """List all stored functions."""
+        valid_sort = {"name", "created_at", "updated_at"}
+        if sort_by not in valid_sort:
+            sort_by = "created_at"
+        order = "DESC" if descending else "ASC"
+        rows = self._db.execute(
+            f"SELECT uid, name, body, created_at, updated_at FROM functions ORDER BY {sort_by} {order}"
+        )
+        return [self._row_to_function(r) for r in rows]
+
+    def update_function(
+        self,
+        uid: int,
+        name: Optional[str] = None,
+        body: Optional[str] = None,
+    ) -> bool:
+        """Update an existing function."""
+        updates = []
+        values = []
+        if name is not None:
+            updates.append("name = ?")
+            values.append(name)
+        if body is not None:
+            updates.append("body = ?")
+            values.append(body)
+        if updates:
+            updates.append("updated_at = ?")
+            values.append(datetime.now(timezone.utc).isoformat())
+            values.append(uid)
+            with self._db.transaction() as conn:
+                conn.execute(f"UPDATE functions SET {', '.join(updates)} WHERE uid = ?", tuple(values))
+            return True
+        return False
+
+    def delete_function(self, uid: int) -> bool:
+        """Delete a function by uid."""
+        with self._db.transaction() as conn:
+            cursor = conn.execute("DELETE FROM functions WHERE uid = ?", (uid,))
+            return cursor.rowcount > 0
+
+    def search_functions(self, query: str) -> list[BashFunction]:
+        """Search functions by name or body."""
+        rows = self._db.execute(
+            "SELECT uid, name, body, created_at, updated_at FROM functions "
+            "WHERE name LIKE ? OR body LIKE ?",
+            (f"%{query}%", f"%{query}%"),
+        )
+        return [self._row_to_function(r) for r in rows]
+
+    def sync_shell_config(self) -> None:
+        """Sync functions to shell config file (generated, read-only)."""
+        functions = self.list_functions()
+        lines = [
+            "#!/bin/bash",
+            "# Auto-generated by A, DO NOT EDIT",
+            "",
+        ]
+        for f in functions:
+            lines.append(f"{f.name}() {{")
+            lines.append(f.body)
+            lines.append("}")
+            lines.append("")
+
+        config = _A_BASH_FUNCTIONS
+        if config.exists():
+            config.chmod(0o644)
+        config.write_text("\n".join(lines) + "\n")
+        config.chmod(0o444)
+
+    def close(self) -> None:
+        """Close database connection (no-op for SQLiteDB)."""
+        pass
+
+
+def parse_function_file(path: Path) -> tuple[str, str]:
+    """Parse a bash function definition from a file.
+
+    Extracts the function name and the body (content between braces).
+
+    Args:
+        path: Path to file containing the function definition
+
+    Returns:
+        Tuple of (name, body)
+
+    Raises:
+        ValueError: If the file doesn't contain a valid function definition
+    """
+    content = path.read_text(encoding="utf-8").strip()
+
+    # Match all three valid bash function definition styles:
+    #   1. name() { ... }
+    #   2. function name { ... }
+    #   3. function name() { ... }
+    func_match = re.match(
+        r"(?:function\s+)?(\w[\w-]*?)\s*(?:\(\))?\s*\{\s*\n?(.*?)\n?\s*\}\s*$",
+        content,
+        re.DOTALL,
+    )
+    if not func_match:
+        raise ValueError(
+            f"File does not contain a valid bash function definition.\n"
+            f"Expected formats:\n"
+            f"  name() {{\n"
+            f"    ...\n"
+            f"  }}\n"
+        )
+
+    name = func_match.group(1)
+    body = func_match.group(2).strip()
+    if not body:
+        raise ValueError(f"Function '{name}' has empty body.")
+
+    return name, body
+
+
+def validate_bash_syntax(name: str, body: str) -> None:
+    """Validate that a function definition is syntactically valid bash.
+
+    Args:
+        name: Function name
+        body: Function body
+
+    Raises:
+        ValueError: If validation fails
+    """
+    # Reconstruct the full function definition for bash -n
+    func_def = f"{name}() {{\n{body}\n}}"
+    try:
+        result = subprocess.run(
+            ["bash", "-n", "-c", func_def],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            msg = result.stderr.strip() or result.stdout.strip() or "syntax error"
+            raise ValueError(f"Bash syntax error: {msg}")
+    except FileNotFoundError:
+        # bash not available — skip validation
+        pass
+    except subprocess.TimeoutExpired:
+        raise ValueError("Bash syntax check timed out.")
+
+
+__all__ = ["BashFunction", "BashFunctionDB", "parse_function_file", "validate_bash_syntax"]


### PR DESCRIPTION
## Summary
Add `A sistemo selo-funkcio` to manage multiline bash functions, complementing existing `selo-aliaso`.

## New CLI
```bash
A sistemo selo-funkcio aldoni ~/myfunc.sh   # Add function from file
A sistemo selo-funkcio ls                    # List functions
A sistemo selo-funkcio modifi <uid> -f file  # Update from file
A sistemo selo-funkcio forigi <uid>          # Delete
A sistemo selo-funkcio vidi <uid>            # View full body
A sistemo selo-funkcio serci <query>         # Search
```

## Architecture
- Separate DB: `~/.config/A/bash_functions.db`
- Generated file: `~/.A_bash_functions` (RO, sourced after ~/.A_bash_alias)
- `bash -n` validation before storing
- Regex handles all 3 bash function styles: `name()`, `function name`, `function name()`