### PR TITLE
fix: replace raw pip install with ensure_dependency('psutil')

### DIFF
--- a/src/A_sistemo/services/system_info.py
+++ b/src/A_sistemo/services/system_info.py
@@ -60,18 +60,13 @@ def collect_system_info() -> SystemInfo:
     try:
         import psutil
     except ImportError:
-        from A import info, error, run
-        import sys
-        info("psutil not found. Auto-installing...")
-        result = run(sys.executable, "-m", "pip", "install", "psutil", timeout=60)
-        if result.returncode == 0:
-            import psutil  # type: ignore[import-untyped]
-        else:
-            error(
-                "Failed to auto-install psutil. "
-                f"Install manually: {sys.executable} -m pip install psutil"
-            )
-            raise SystemExit(1)
+        from A.utils.deps import ensure_dependency
+
+        try:
+            ensure_dependency("psutil", timeout=60)
+        except ImportError:
+            raise SystemExit(1) from None
+        import psutil  # type: ignore[import-untyped]
 
     uname = platform.uname()
     try:

--- a/tests/test_sistemo.py
+++ b/tests/test_sistemo.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 from typer.testing import CliRunner
 
@@ -40,6 +42,45 @@ class TestSistemo:
         assert result.exit_code == 0
 
     def test_rubo_help(self):
-        """Test rubo subcommand help."""
+        """Test trash subcommand help."""
         result = runner.invoke(app, ["rubo", "--help"])
         assert result.exit_code == 0
+
+
+class TestSystemInfoPsutilInstall:
+    """collect_system_info() must auto-install psutil when missing."""
+
+    def test_psutil_installed_already(self) -> None:
+        """When psutil is already importable, no install needed."""
+        from A_sistemo.services.system_info import collect_system_info
+
+        # Ensure psutil is importable for this test
+        import psutil  # noqa: F401
+
+        # Should not raise — fast path
+        result = collect_system_info()
+        assert result.os_name is not None
+
+    def test_psutil_missing_calls_ensure_dependency(self) -> None:
+        """When psutil missing, delegates to ensure_dependency('psutil')
+        and raises SystemExit on failure."""
+        import builtins
+
+        original_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "psutil" or name == "psutil." or name.startswith("psutil."):
+                raise ImportError(f"No module named {name}")
+            return original_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", fake_import):
+            # Ensure dependency fails → SystemExit(1)
+            with patch(
+                "A.utils.deps.ensure_dependency",
+                side_effect=ImportError("fail"),
+            ) as mock_ed:
+                from A_sistemo.services.system_info import collect_system_info
+
+                with pytest.raises(SystemExit):
+                    collect_system_info()
+                mock_ed.assert_called_once_with("psutil", timeout=60)


### PR DESCRIPTION
Replace `sys.executable -m pip install psutil` with `A.utils.deps.ensure_dependency('psutil')` for uv-first priority install.

- Add tests: fast path, delegation with SystemExit on failure

Refs: #16