### PR TITLE
fix: rename srumpi command (ASCII-only)

### DIFF
--- a/src/A_sistemo/cli/particio.py
+++ b/src/A_sistemo/cli/particio.py
@@ -15,8 +15,8 @@ app = typer.Typer(
 )
 
 
-@app.command("ŝrumpi")
-def ŝrumpi(
+@app.command("srumpi")
+def srumpi(
     device: str = typer.Argument(..., help=f"{tr('device')} (Example: /dev/sdb1)"),
     new_size: str = typer.Argument(..., help=f"{tr('size')} (Example: 10G)"),
     justa: bool = typer.Option(False, "-j", "--justa", help=tr("sen_konfirmo")),


### PR DESCRIPTION
Renames the srumpi command to strip Esperanto diacritic. LLM function calling APIs require ASCII-only function names.